### PR TITLE
Add generalized meta, style, and script helpers

### DIFF
--- a/app/templates/_includes/head.html
+++ b/app/templates/_includes/head.html
@@ -15,3 +15,5 @@
   {% include meta.html %}
 
   <link rel="canonical" href="{{ site.url }}{{ page.url }}">
+
+  {% include stylesheets.html %}

--- a/app/templates/_includes/head.html
+++ b/app/templates/_includes/head.html
@@ -1,25 +1,17 @@
-<!-- Basic Page Needs
-================================================== -->
+  <!-- Basic Page Needs -->
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-<!-- Mobile Specific Metas
-================================================== -->
+  <!-- Mobile Specific Metas -->
   <meta name="HandheldFriendly" content="True">
   <meta name="MobileOptimized" content="320">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<!-- Title and meta description
-================================================== -->
+  <title>
+    {% if page.title %}{{ page.title | xml_escape }} / {% endif %}
+    {{ site.title | xml_escape }}
+  </title>
 
-<title>{{ site.name }}</title>
-<meta property="og:title" content="{{ site.name | xml_escape }} | {{ site.title | xml_escape }}" />
+  {% include meta.html %}
 
-<meta name="description" content="{{ site.description | xml_escape }}">
-<meta property="og:description" content="{{ site.description | xml_escape }}" />
-
-<link rel="canonical" href="{{ site.url }}{{ page.url }}" />
-
-<!-- CSS
-================================================== -->
-  <link rel="stylesheet" href="{{ "/assets/stylesheets/main.css" | prepend: site.baseurl }}">
+  <link rel="canonical" href="{{ site.url }}{{ page.url }}">

--- a/app/templates/_includes/meta.html
+++ b/app/templates/_includes/meta.html
@@ -1,0 +1,11 @@
+{% capture _meta_ %}
+{% assign _meta_names = 'title description' | split: ' ' %}
+{% for _meta in site.meta %}{% unless _meta_names contains _meta[0] %}{% assign _meta_names = _meta_names | push: _meta[0] %}{% endunless %}{% endfor %}
+{% for _meta in page.meta %}{% unless _meta_names contains _meta[0] %}{% assign _meta_names = _meta_names | push: _meta[0] %}{% endunless %}{% endfor %}
+{% for _meta in _meta_names %}
+  {% capture _meta_content %}{% if _meta contains ':image' %}{{ site.url }}{% endif %}{{ page.meta[_meta] | default: site.meta[_meta] | default: site[_meta] }}{% endcapture %}
+  {% if _meta_content %}<meta name="{{ _meta }}" content="{{ _meta_content | xml_escape }}">{% unless _meta contains ':' %}
+  <meta property="og:{{ _meta }}" content="{{ _meta_content | xml_escape }}">{% endunless %}{% endif %}
+{% endfor %}
+  <!-- meta tags: {{ _meta_names | jsonify }} -->
+{% endcapture _meta_ %}{{ _meta_ | strip }}

--- a/app/templates/_includes/scripts.html
+++ b/app/templates/_includes/scripts.html
@@ -1,0 +1,4 @@
+{% for script in site.scripts %}
+    <script src="{{ site.baseurl }}{{ script.src | default: script }}"{% if script.async %} async{% endif %}></script>{% endfor %}
+{% for script in page.scripts %}
+    <script src="{{ site.baseurl }}{{ script.src | default: script }}"{% if script.async %} async{% endif %}></script>{% endfor %}

--- a/app/templates/_includes/stylesheets.html
+++ b/app/templates/_includes/stylesheets.html
@@ -1,0 +1,6 @@
+  <!-- site CSS -->
+{% for sheet in site.stylesheets %}
+  <link rel="stylesheet" href="{{ sheet.href | default: sheet }}"{% if sheet.media %} media="{{ sheet.media }}"{% endif %}>{% endfor %}
+  <!-- page CSS -->
+{% for sheet in page.stylesheets %}
+  <link rel="stylesheet" href="{{ sheet.href | default: sheet }}"{% if sheet.media %} media="{{ sheet.media }}"{% endif %}>{% endfor %}

--- a/app/templates/_layouts/base.html
+++ b/app/templates/_layouts/base.html
@@ -10,6 +10,7 @@
 
     {{ content }}
 
+    {% include scripts.html %}
   </body>
 
 </html>

--- a/app/templates/config.yml
+++ b/app/templates/config.yml
@@ -1,17 +1,23 @@
 title: <%= name %>
 description: <%= description %>
+
+# add any site-wide meta tags here
+meta:
+  og:type: site
+
+# this should *not* include the trailing slash
 url: 
 
 markdown: redcarpet
 highlighter: rouge
 
 exclude:
-- Gemfile
-- Gemfile.lock
-- README.md
-- LICENSE.md
-- CONTRIBUTING.md
-- ".sass-cache"
-- ".ruby-version"
-- vendor
-- node_modules
+  - Gemfile
+  - Gemfile.lock
+  - README.md
+  - LICENSE.md
+  - CONTRIBUTING.md
+  - '.sass-cache'
+  - '.ruby-version'
+  - vendor
+  - node_modules

--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,3 +1,5 @@
-node_modules
+.*.sw?
 .sass-cache
 .DS_Store
+_site
+node_modules

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,4 +2,4 @@
 layout: base
 ---
 
-Welcome to {{ site }}!
+Welcome to {{ site.title }}!

--- a/app/templates/page.md
+++ b/app/templates/page.md
@@ -1,0 +1,16 @@
+---
+layout: base
+title: Some page
+permalink: /page/
+
+meta:
+  og:image: /some/image.jpg
+
+stylesheets:
+  - /css/page.css
+
+scripts:
+  - /js/page.js
+---
+
+Welcome to my page!


### PR DESCRIPTION
This PR introduces three new includes that turn meta data, stylesheets, and scripts into data that can be configured at the site and/or page level:
1. [meta.html](https://github.com/18F/generator-18F-static/blob/site-helpers/app/templates/_includes/meta.html) outputs `<meta>` tags for `title`, `description`, and any other fields defined in either the site config _or_ an individual page's `meta` object. The default config sets `og:type` as an example of site-level metadata, and the dummy [page.md](https://github.com/18F/generator-18F-static/blob/site-helpers/app/page.md) shows an example of page-level metadata with an `og:image` (which gets prepended with `site.url`, since image hrefs need to be fully-qualified).
2. [stylesheets.html](https://github.com/18F/generator-18F-static/blob/site-helpers/app/templates/_includes/stylesheets.html) outputs a series of `<link>` tags for each entry in `site.stylesheets`, then does the same for `page.stylesheets`. In both cases, stylesheets may either be a string (e.g. `/css/main.css` or an object with `href` and optional `media` keys, in which case the corresponding `media` attribute will be added. (By default, there is no `media` attribute.)
3. Similarly, [scripts.html](https://github.com/18F/generator-18F-static/blob/site-helpers/app/templates/_includes/scripts.html) outputs a series of `<script>` tags at the end of the `<body>` in the base layout for each entry in `site.scripts` and `page.scripts`. If the script is an object with a `src` property, then the corresponding attribute gets that value and the `async` property is set if `script.async == true`. Otherwise, the script is treated as a URI, e.g. `/js/main.js`.
