### PR TITLE
Add support for Google Analytics and DAP

### DIFF
--- a/app/templates/_includes/analytics.html
+++ b/app/templates/_includes/analytics.html
@@ -1,0 +1,19 @@
+{% if site.analytics.google %}
+    <!-- google analytics -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('create', '{{ site.analytics.google }}', 'auto');
+      ga('set', 'anonymizeIp', true);
+      ga('set', 'forceSSL', true);
+      ga('send', 'pageview');
+    </script>
+{% endif %}
+
+{% if site.analytics.dap %}
+    <!-- Digital Analytics Program snippet -->
+    <script src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js" id="_fed_an_ua_tag"></script>
+{% endif %}

--- a/app/templates/_includes/scripts.html
+++ b/app/templates/_includes/scripts.html
@@ -1,4 +1,10 @@
+{% if site.scripts %}
+    <!-- site scripts -->
 {% for script in site.scripts %}
     <script src="{{ site.baseurl }}{{ script.src | default: script }}"{% if script.async %} async{% endif %}></script>{% endfor %}
+{% endif %}
+{% if page.scripts %}
+    <!-- page scripts -->
 {% for script in page.scripts %}
     <script src="{{ site.baseurl }}{{ script.src | default: script }}"{% if script.async %} async{% endif %}></script>{% endfor %}
+{% endif %}

--- a/app/templates/_includes/stylesheets.html
+++ b/app/templates/_includes/stylesheets.html
@@ -1,6 +1,10 @@
+{% if site.stylesheets %}
   <!-- site CSS -->
 {% for sheet in site.stylesheets %}
   <link rel="stylesheet" href="{{ sheet.href | default: sheet }}"{% if sheet.media %} media="{{ sheet.media }}"{% endif %}>{% endfor %}
+{% endif %}
+{% if page.stylesheets %}
   <!-- page CSS -->
 {% for sheet in page.stylesheets %}
   <link rel="stylesheet" href="{{ sheet.href | default: sheet }}"{% if sheet.media %} media="{{ sheet.media }}"{% endif %}>{% endfor %}
+{% endif %}

--- a/app/templates/_layouts/base.html
+++ b/app/templates/_layouts/base.html
@@ -11,6 +11,7 @@
     {{ content }}
 
     {% include scripts.html %}
+    {% include analytics.html %}
   </body>
 
 </html>

--- a/app/templates/config.yml
+++ b/app/templates/config.yml
@@ -6,7 +6,16 @@ meta:
   og:type: site
 
 # this should *not* include the trailing slash
-url: 
+url: ''
+
+# for more on 18F analytics standards, see:
+# https://github.com/18F/analytics-standards#18f-team-standards-for-analytics
+analytics:
+  # set this to your Google Analytics UA code
+  google: false
+  # set this to true when you're ready to include the Digital Analytics Project
+  # snippet
+  dap: false
 
 markdown: redcarpet
 highlighter: rouge


### PR DESCRIPTION
Fixes #3.

This adds an [analytics.html](https://github.com/18F/generator-18F-static/blob/analytics/app/templates/_includes/analytics.html) include that gets tacked on a the very bottom of the base layout. Configuration is managed in [_config.yml](https://github.com/18F/generator-18F-static/blob/analytics/app/templates/config.yml) via the `analytics` object, which can have two keys:
- `google` should be set to the site's Google Analytics UA code.
- `dap` should be `true` when the site is ready to include the [DAP snippet](https://github.com/18F/analytics-standards#digital-analytics-program-snippet).

I've documented these and linked to the [18F analytics standards](https://github.com/18F/analytics-standards#18f-team-standards-for-analytics) in the [config](https://github.com/18F/generator-18F-static/blob/analytics/app/templates/config.yml) if people are interested in learning more about how to get a GA code or what DAP is.
