### PR TITLE
[WIP] Unit test scaffolding with mocha + jsdom

### DIFF
--- a/generators/test-unit/index.js
+++ b/generators/test-unit/index.js
@@ -119,6 +119,8 @@ module.exports = require('yeoman-generator').Base.extend({
         framework + '/' + specPath
       );
 
+      // FIXME this doesn't work for some reason...
+      // maybe this.fs.exists() isn't synchronous?
       var templatePath = this.fs.exists(frameworkAssertionPath)
         ? frameworkAssertionPath
         : frameworkPath;

--- a/generators/test-unit/index.js
+++ b/generators/test-unit/index.js
@@ -1,0 +1,154 @@
+'use strict';
+var chalk = require('chalk');
+var yosay = require('yosay');
+
+module.exports = require('yeoman-generator').Base.extend({
+
+  initializing: function () {
+    this.pkg = require('../../package.json');
+
+    this.option('skip-install', {
+      type: Boolean,
+      desc: 'Skip automatic installation of npm dependencies'
+    });
+  },
+
+  prompting: function () {
+    this.log(yosay(
+      'So, you want to add ' + chalk.yellow('JS unit tests') + ', eh?'
+    ));
+
+    var prompts = [
+      {
+        type: 'list',
+        name: 'framework',
+        message: 'Which framework would you like to use?',
+        choices: [
+          'jasmine',
+          'mocha'
+        ],
+        default: 'mocha'
+      },
+      {
+        type: 'list',
+        name: 'assert',
+        message: 'Which assertion style would you like to use?',
+        choices: [
+          'assert',
+          'expect',
+          'should'
+        ],
+        default: 'assert'
+      },
+      {
+        type: 'confirm',
+        name: 'jsdom',
+        message: 'Do your tests require a browser-like DOM environment (jsdom)?',
+        default: true
+      }
+    ];
+
+    var options = this.options;
+    return this.prompt(prompts)
+      .then(function (opts) {
+        Object.assign(options, opts);
+      });
+  },
+
+  writing: {
+
+    updatePackageJSON: function () {
+      var deps = {};
+      var framework = this.options.framework;
+      var assert = this.options.assert;
+      deps[framework] = '*';
+
+      if (assert && assert !== 'assert') {
+        deps[assert] = '*';
+      }
+
+      if (this.options.jsdom) {
+        this.log(chalk.green('adding jsdom!'));
+        deps['jsdom'] = '*';
+        deps['jsdom-global'] = '*';
+      } else {
+        this.log(chalk.yellow('no jsdom for you.'));
+      }
+
+      var packageJSON = this.destinationPath('package.json');
+
+      // backup the old package.json
+      /*
+      this.fs.copy(
+        packageJSON,
+        packageJSON + '.backup'
+      );
+      */
+
+      this.fs.extendJSON(
+        packageJSON,
+        {
+          'devDependencies': deps,
+          'scripts': {
+            'test-unit': [
+              framework,
+              'test/unit/**/*.spec.js'
+            ].join(' ')
+          }
+        }
+      );
+    },
+
+    createTestDir: function () {
+
+      // copy example library functions to test
+      this.fs.copy(
+        this.templatePath('lib'),
+        this.destinationPath('lib')
+      );
+
+      var framework = this.options.framework;
+      var assert = this.options.assert;
+      var specPath = 'test/unit';
+
+      var frameworkAssertionPath = this.templatePath([
+        framework, '-', assert, '/', specPath
+      ].join(''));
+
+      var frameworkPath = this.templatePath(
+        framework + '/' + specPath
+      );
+
+      var templatePath = this.fs.exists(frameworkAssertionPath)
+        ? frameworkAssertionPath
+        : frameworkPath;
+      this.fs.copy(
+        templatePath,
+        this.destinationPath(specPath)
+      );
+
+      switch (framework) {
+        case 'mocha':
+          var opts = [];
+          if (this.options.jsdom) {
+            opts.push('-r', 'jsdom-global/register');
+          }
+          if (opts.length) {
+            this.fs.write(
+              this.destinationPath('test/mocha.opts'),
+              opts.join(' ')
+            );
+          }
+          break;
+      }
+    },
+
+  },
+
+  install: function () {
+    if (this.options['skip-install'] !== true) {
+      this.npmInstall();
+    }
+  },
+
+});

--- a/generators/test-unit/templates/lib/lower.js
+++ b/generators/test-unit/templates/lib/lower.js
@@ -1,0 +1,4 @@
+// this is an example library function to test
+module.exports = function(d) {
+  return String(d).toLowerCase();
+};

--- a/generators/test-unit/templates/mocha/test/unit/example.spec.js
+++ b/generators/test-unit/templates/mocha/test/unit/example.spec.js
@@ -1,0 +1,12 @@
+'use strict';
+var assert = require('assert');
+
+describe('lower()', function() {
+
+  var lower = require('../../lib/lower');
+
+  it('returns a lowercase string', function() {
+    assert.equal(lower('Foo Bar'), 'foo bar');
+  });
+
+});


### PR DESCRIPTION
This is a first pass at what a generator for JS unit tests might look like. @msecret, take a look if you have some time and let's chat about it soon. Here's the skinny:
1. Prompt: which test framework to use. We offer [Jasmine](http://jasmine.github.io/) and [Mocha](http://mochajs.org/), but only Mocha has unit test scaffolding currently. (The APIs are very similar, though.)
2. Prompt: which assertion style/library to use. I offer Node's native `assert` (the default), [expect](https://www.npmjs.com/package/expect), and [should](https://shouldjs.github.io/); but currently the native `assert` is the only one used in the example spec. Maybe we should offer [chai](http://chaijs.com/), too, or instead of expect? **Or maybe we settle on Jasmine because it just includes [expect-like assertions](http://jasmine.github.io/2.4/introduction.html#section-Expectations) out of the box?**
3. Prompt: do you need a "browser-like DOM?" If so, we [add](https://github.com/18F/generator-18F-static/blob/test-unit/generators/test-unit/index.js#L71-L73) [jsdom](https://github.com/tmpvar/jsdom) and [jsdom-global](https://npm.im/jsdom-global) to the dependencies. If the test framework is Mocha, then we also [register jsdom-global in `mocha.opts`](https://github.com/18F/generator-18F-static/blob/test-unit/generators/test-unit/index.js#L133-L143). This means that you have a pure-JS DOM in all of your unit tests!
4. Install the requisite npm `devDependencies`.
5. Copy the `test/unit` directory from the requested framework's template directory, which includes an [example spec](https://github.com/18F/generator-18F-static/blob/test-unit/generators/test-unit/templates/mocha/test/unit/example.spec.js) for [lib/lower.js](https://github.com/18F/generator-18F-static/blob/test-unit/generators/test-unit/templates/lib/lower.js).
6. Add a `test` script that runs `{framework} test/unit/**/*.spec.js`.

A lot of the logic for this lives in JS rather than in a templated `package.json`, but that's really just because I'm not super familiar with EJS templates and wanted to get things done. I'm happy to move the logic into a template if that's what y'all would prefer.

I'm not sure about the best way to incorporate this into the main generator, or if there's a standard practice around that with Yeoman. For instance, does the main one just add a prompt for whether the user wants JS unit tests, then "composes" this one if so? @juliaelman, maybe you know something about this?
